### PR TITLE
[#162511174] Adding Deep Linking Settings Prompt For Users Who Deny Media Files Access With Fraud Prompts

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.google.gms:google-services:3.2.0'
     }
 }

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
         classpath 'com.google.gms:google-services:3.2.0'
         // NOTE: Do not place your application dependencies here; they belong

--- a/Example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Thu Jun 09 11:55:07 EDT 2016
-#Tue May 08 11:26:54 PDT 2018
+#Wed Apr 17 12:11:11 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -103,31 +103,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       if (!permissionsGranted)
       {
         responseHelper.invokeError(callback, "Permissions weren't granted");
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMessage("Please go to Settings to allow Skillz to access media files.")
-               .setPositiveButton("Settings", new DialogInterface.OnClickListener() {
-                 @Override
-                 public void onClick(DialogInterface dialog, int which) {
-                   Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                   intent.setData(Uri.parse("package:" + getContext().getPackageName()));
-                   intent.putExtra("Permission", true);
-                   intent.addCategory(Intent.CATEGORY_DEFAULT);
-                   intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                   intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-                   intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-                   try {
-                     getActivity().startActivityForResult(intent, 151); // Settings request code
-                   } catch (ActivityNotFoundException ignored) {
-                   }
-                 }
-               })
-               .setNegativeButton("Dismiss", new DialogInterface.OnClickListener() {
-                 @Override
-                 public void onClick(DialogInterface dialog, int which) {
-                 }
-        });
-        builder.create();
-        builder.show();
+        showSettingsModal();
         return false;
       }
 
@@ -549,6 +525,35 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     return callback == null || (cameraCaptureURI == null && requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE)
             || (requestCode != REQUEST_LAUNCH_IMAGE_CAPTURE && requestCode != REQUEST_LAUNCH_IMAGE_LIBRARY
             && requestCode != REQUEST_LAUNCH_VIDEO_LIBRARY && requestCode != REQUEST_LAUNCH_VIDEO_CAPTURE);
+  }
+
+  private void showSettingsModal()
+  {
+    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+    builder.setMessage("Please go to Settings to allow Skillz to access media files.")
+            .setPositiveButton("Settings", new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+                Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+                intent.putExtra("Permission", true);
+                intent.addCategory(Intent.CATEGORY_DEFAULT);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+                intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+                try {
+                  getActivity().startActivityForResult(intent, 151); // Settings request code
+                } catch (ActivityNotFoundException ignored) {
+                }
+              }
+            })
+            .setNegativeButton("Dismiss", new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+              }
+            });
+    builder.create();
+    builder.show();
   }
 
   private void updatedResultResponse(@Nullable final Uri uri,

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -103,6 +103,31 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       if (!permissionsGranted)
       {
         responseHelper.invokeError(callback, "Permissions weren't granted");
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage("Please go to Settings to allow Skillz to access media files.")
+               .setPositiveButton("Settings", new DialogInterface.OnClickListener() {
+                 @Override
+                 public void onClick(DialogInterface dialog, int which) {
+                   Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                   intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+                   intent.putExtra("Permission", true);
+                   intent.addCategory(Intent.CATEGORY_DEFAULT);
+                   intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                   intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+                   intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+                   try {
+                     getActivity().startActivityForResult(intent, 151); // Settings request code
+                   } catch (ActivityNotFoundException ignored) {
+                   }
+                 }
+               })
+               .setNegativeButton("Dismiss", new DialogInterface.OnClickListener() {
+                 @Override
+                 public void onClick(DialogInterface dialog, int which) {
+                 }
+        });
+        builder.create();
+        builder.show();
         return false;
       }
 


### PR DESCRIPTION
- Added a prompt that appears whenever a user denies our repeated media files access modals and hits "Don't ask again. The copy of the modal matches our prompt for contacts access aside from the word "contacts".
- Also bumped the gradle build tools version.

(This attached gif comes from the React Native Image Picker Example Project since we can't grab local changes to this node module for use in our SDK.)
![Media Access Modal Example](https://user-images.githubusercontent.com/32800442/56317487-bb867400-6111-11e9-9763-6d31c1426363.gif)