### PR TITLE
[#165924407] Exposing showSettingsModal Method

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -527,6 +527,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
             && requestCode != REQUEST_LAUNCH_VIDEO_LIBRARY && requestCode != REQUEST_LAUNCH_VIDEO_CAPTURE);
   }
 
+  @ReactMethod
   private void showSettingsModal()
   {
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -528,7 +528,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   }
 
   @ReactMethod
-  private void showSettingsModal()
+  public void showSettingsModal()
   {
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
     builder.setMessage("Please go to Settings to allow Skillz to access media files.")


### PR DESCRIPTION
- Making showSettingsModal() a React Method so that we can call this from the JS side when launching the image library fails because of repeated permissions checks.